### PR TITLE
fix: remove build command in the gha

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -17,8 +17,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Run npm install ci
         run: npm ci --only=production
-      - name: Run Build
-        run: npm run build
       - name: Publish package
         run: npm publish --ignore-scripts --access public
         env:


### PR DESCRIPTION
### What’s the focus of this PR
- Remove build command used in the github action
