### PR TITLE
Add standard-version to generate releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.0.3](https://github.com/guidesmiths/systemic-aws-s3/compare/v1.0.2...v1.0.3) (2021-10-22)
+
+
+### Features
+
+* add standard-version ([2c25c8a](https://github.com/guidesmiths/systemic-aws-s3/commit/2c25c8af1727d5334b6c88c0ee070af5a23c835c))
+
+
+### Bug Fixes
+
+* husky fix ([34caf9a](https://github.com/guidesmiths/systemic-aws-s3/commit/34caf9a89bc142ae65a6a58e0ed197f7f4af69f1))
+* solve merge conflicts ([c38cef6](https://github.com/guidesmiths/systemic-aws-s3/commit/c38cef64e4c8059bec94dbb1fb0342c5a785ad5b))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guidesmiths/systemic-aws-s3",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guidesmiths/systemic-aws-s3",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidesmiths/systemic-aws-s3",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A systemic component for AWS S3 service",
   "main": "index.js",
   "scripts": {
@@ -10,10 +10,10 @@
     "test:watch": "npm run infra:up && NODE_ENV=test jest --watchAll && npm run infra:down",
     "prepare": "husky install",
     "release": "standard-version",
-		"release:major": "npm run release -- --release-as major",
-		"release:minor": "npm run release -- --release-as minor",
-		"release:patch": "npm run release -- --release-as patch",
-		"release:alpha": "npm run release -- --prerelease alpha",
+    "release:major": "npm run release -- --release-as major",
+    "release:minor": "npm run release -- --release-as minor",
+    "release:patch": "npm run release -- --release-as patch",
+    "release:alpha": "npm run release -- --prerelease alpha",
     "lint": "eslint --ext .js .",
     "lint:fix": "eslint --ext .js . --fix"
   },


### PR DESCRIPTION
### What’s the focus of this PR
🌈  &nbsp; Automate generation of CHANGELOG and release. Your be able to generate pre release, patch, minor, major following [semantic versioning](https://semver.org/) 

### How to review this PR
👀 &nbsp; You only need run one of the following scripts:

- `release:major`
- `release:minor`
- `release:patch`
- `release:alpha`

And see how the magic happens &nbsp; 🦄

